### PR TITLE
Respond to Heartbeat

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,12 @@ func main() {
 				return
 			}
 
-			fmt.Printf("%s", bytes.NewBuffer(messageBytes).String())
+			message := bytes.NewBuffer(messageBytes).String()
+			if message == "PING :tmi.twitch.tv\r\n" {
+				conn.WriteMessage(1, []byte("PONG :tmi.twitch.tv\r\n"))
+			}
+
+			fmt.Printf("%s", message)
 		}
 	}()
 


### PR DESCRIPTION
Heartbeat must be responded to with the appropriate message in order to maintain the websocket connection. Failure to do so will eventually result in a `websocket: close 1006 (abnormal closure): unexpected EOF`.